### PR TITLE
add waf for alb to prevent basic attacks

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -67,6 +67,11 @@ module "alb" {
   depends_on = [module.s3]
 }
 
+module "alb_waf" {
+  source = "./modules/waf"
+  alb_arn = module.alb.alb_arn
+}
+
 module "ecr_core_server" {
   source = "./modules/ecr/core_server"
 }

--- a/terraform/modules/alb/outputs.tf
+++ b/terraform/modules/alb/outputs.tf
@@ -3,6 +3,11 @@ output "alb_id" {
   value = aws_lb.main.id
 }
 
+output "alb_arn" {
+  description = "The arn of the main alb"
+  value = aws_lb.main.arn
+}
+
 output "web_target_group_arn" {
   description = "The ARN of the target group for the web service"
   value = aws_lb_target_group.web_target_group.arn

--- a/terraform/modules/waf/main.tf
+++ b/terraform/modules/waf/main.tf
@@ -1,0 +1,87 @@
+resource "aws_wafv2_web_acl" "generic_waf" {
+  name        = "generic-waf"
+  description = "Web ACL to block common attack requests and specific unwanted patterns."
+  scope       = "REGIONAL"  # Use "REGIONAL" for ALBs; for CloudFront, use "CLOUDFRONT"
+
+  default_action {
+    allow {}
+  }
+
+  rule {
+    name     = "AWSManagedRulesCommonRuleSet"
+    priority = 1
+    override_action {
+      none {}
+    }
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesCommonRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesCommonRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  rule {
+    name     = "AWSManagedRulesSQLiRuleSet"
+    priority = 2
+    override_action {
+      none {}
+    }
+    statement {
+      managed_rule_group_statement {
+        name        = "AWSManagedRulesSQLiRuleSet"
+        vendor_name = "AWS"
+      }
+    }
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "AWSManagedRulesSQLiRuleSet"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  # Custom rule to block requests containing '.aspx'
+  rule {
+    name     = "BlockASPXRequests"
+    priority = 3
+    
+    action {
+      block {}
+    }
+
+    statement {
+      regex_match_statement {
+        field_to_match {
+          uri_path {}
+        }
+        regex_string = ".*\\.aspx.*"
+        text_transformation {
+          priority = 0
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "BlockASPXRequests"
+      sampled_requests_enabled   = true
+    }
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "genericWaf"
+    sampled_requests_enabled   = true
+  }
+}
+
+resource "aws_wafv2_web_acl_association" "alb_association" {
+  resource_arn = var.alb_arn
+  web_acl_arn  = aws_wafv2_web_acl.generic_waf.arn
+}

--- a/terraform/modules/waf/variables.tf
+++ b/terraform/modules/waf/variables.tf
@@ -1,0 +1,4 @@
+variable "alb_arn" {
+  description = "The ARN of the ALB"
+  type        = string
+}


### PR DESCRIPTION
- The ALB was already getting queried by attacks, that was fast.  Adding a basic WAF to prevent the standards outlined by AWS